### PR TITLE
Require click >= 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     packages=find_packages(),
     entry_points={"console_scripts": ["isic = isic_cli.cli:main"]},
     install_requires=[
-        "click",
+        # we use the path_type=Path feature from click which was added in Click 8
+        "click>=8",
         "django-s3-file-field-client",
         "girder-cli-oauth-client",
         "humanize",


### PR DESCRIPTION
This fixes the error seen in the wild:
```
'bytes' object has no attribute 'mkdir'
```

Where the `click.Path` type was being passed as a bytestring because of an older version of click which didn't support coercion to a `Pathlib.Path`.