### PR TITLE
Add debug log for initialization

### DIFF
--- a/isic_cli/session.py
+++ b/isic_cli/session.py
@@ -54,6 +54,7 @@ class IsicCliSession(RetryableSession):
 def get_session(
     base_url: str = "https://api.isic-archive.com/api/v2/", headers: Optional[dict] = None
 ) -> IsicCliSession:
+    logger.debug(f"Establishing requests session with {base_url}")
     session = IsicCliSession(base_url)
     if headers:
         session.headers.update(headers)


### PR DESCRIPTION
This is useful if the upstream URL is misconfigured and it can never form a connection. Instead of waiting for timeouts the verbose logging can help point to the problem immediately.