### PR TITLE
Rename package file name

### DIFF
--- a/.github/zip_and_upload_package.sh
+++ b/.github/zip_and_upload_package.sh
@@ -14,7 +14,7 @@ else
 fi
 
 chmod +x $executable
-zipfile="${runner_os}-isic-cli.zip"
+zipfile="isic-cli_${runner_os}.zip"
 
 if [[ "$runner_os" = "Windows" ]]; then
     tar.exe -a -c -f $zipfile $executable


### PR DESCRIPTION
It's more intuitive to name the file `isic-cli...` for finding it among downloads.